### PR TITLE
Use dedicated Go module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # git-urls
 
-Docs: https://pkg.go.dev/github.com/whilp/git-urls?tab=overview
+Docs: https://pkg.go.dev/github.com/chainguard-dev/git-urls?tab=overview

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/whilp/git-urls
+module github.com/chainguard-dev/git-urls
 
 go 1.19


### PR DESCRIPTION
I understand this fork is supposed to be long-lasting so it'd be great to have it declare its own import path. That way it's not necessary to use `replace` directives downstream.